### PR TITLE
Avoid leaking memory with CString::into_raw()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,7 +247,7 @@ impl Regex {
 
         unsafe {
             let mut regex: regex_t = mem::zeroed();
-            let errcode = regcomp(&mut regex, pattern.into_raw(), flags.bits());
+            let errcode = regcomp(&mut regex, pattern.as_ptr(), flags.bits());
 
             if errcode == 0 {
                 Ok(Regex { regex })
@@ -291,7 +291,7 @@ impl Regex {
 
             regexec(
                 &self.regex,
-                input.into_raw(),
+                input.as_ptr(),
                 max_matches as libc::size_t,
                 pmatch.as_mut_ptr(),
                 flags.bits(),


### PR DESCRIPTION
Related Newsboat issue: https://github.com/newsboat/newsboat/issues/3266 and PR: https://github.com/newsboat/newsboat/pull/3271

These issues can also be shown with the following cargo/environment flags:
```
RUSTFLAGS='-Zsanitizer=address' RUSTDOCFLAGS='-Zsanitizer=address' cargo +nightly test
```